### PR TITLE
setup.py: change to comply with PEP440 local version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version=load_version() + "-huddly",
+    version=load_version() + "+huddly",
 
     description='Conan C/C++ package manager',
     long_description=generate_long_description_file(),


### PR DESCRIPTION
Github actions started to complain, changing to comply with this:
https://peps.python.org/pep-0440/#local-version-identifiers